### PR TITLE
Add support for Authenticated Repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>netwolfuk.teamcity.plugins.tcdebrepo</groupId>
   <artifactId>tcdebrepo</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>pom</packaging>
   <properties>
       <teamcity-version>10.0</teamcity-version>

--- a/tcdebrepo-build/pom.xml
+++ b/tcdebrepo-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>tcdebrepo</artifactId>
     <groupId>netwolfuk.teamcity.plugins.tcdebrepo</groupId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
   <artifactId>tcdebrepo-build</artifactId>
   <packaging>pom</packaging>
@@ -18,7 +18,7 @@
       <dependency>
            <groupId>netwolfuk.teamcity.plugins.tcdebrepo</groupId>
            <artifactId>tcdebrepo-server</artifactId>
-           <version>1.0.1</version>
+           <version>1.0.2</version>
       </dependency>
   </dependencies>
   <build>

--- a/tcdebrepo-server/pom.xml
+++ b/tcdebrepo-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>tcdebrepo</artifactId>
 		<groupId>netwolfuk.teamcity.plugins.tcdebrepo</groupId>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 	</parent>
 	<artifactId>tcdebrepo-server</artifactId>
 	<packaging>jar</packaging>

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/ebean/server/DebRepositoryManagerImpl.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/ebean/server/DebRepositoryManagerImpl.java
@@ -97,7 +97,7 @@ public class DebRepositoryManagerImpl extends DebRepositoryConfigurationManagerI
 		for (DebRepositoryBuildTypeConfig btConfig : config.getBuildTypes()) {
 			filterCount = filterCount + btConfig.getDebFilters().size();
 		}
-		return new DebRepositoryStatistics(count, repoUrl, filterCount);
+		return new DebRepositoryStatistics(count, repoUrl, filterCount, config.isRestricted());
 	}
 
 	@Override

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryConfiguration.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryConfiguration.java
@@ -29,6 +29,8 @@ public interface DebRepositoryConfiguration extends Comparable<DebRepositoryConf
 	public abstract UUID getUuid();
 	public abstract String getRepoName();
 	public abstract void setRepoName(String repoName);
+	public abstract boolean isRestricted();
+	public abstract void setRestricted(boolean restricted);
 	public abstract boolean containsBuildType(String buildTypeid);
 	public abstract List<DebRepositoryBuildTypeConfig> getBuildTypes();
 	public abstract boolean addBuildType(DebRepositoryBuildTypeConfig buildTypeConfig);

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryConfigurationJaxImpl.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryConfigurationJaxImpl.java
@@ -16,7 +16,6 @@
 package debrepo.teamcity.entity;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -34,7 +33,6 @@ import javax.xml.bind.annotation.XmlType;
 import org.jetbrains.annotations.NotNull;
 
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /* Use the XmlAttributes on the fields rather than the getters
@@ -45,7 +43,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor // Empty constructor for JAXB.
 
 @XmlRootElement()
-@XmlType(propOrder = { "repoName", "projectId", "uuid", "buildTypes", "architecturesRepresentedByAll" })
+@XmlType(propOrder = { "repoName", "projectId", "restricted", "uuid", "buildTypes", "architecturesRepresentedByAll" })
 public class DebRepositoryConfigurationJaxImpl implements DebRepositoryConfiguration {
 	
 	private static final String[] defaultArchitecturesForAll = { "arm64", "amd64", "armel", "amd64", "armhf", 
@@ -61,6 +59,9 @@ public class DebRepositoryConfigurationJaxImpl implements DebRepositoryConfigura
 	
 	@NotNull @XmlAttribute(name="repository-name")
 	private String repoName;
+	
+	@XmlAttribute(name="restricted")
+	private boolean restricted = false;
 	
 	@XmlElement(name="build-type") @XmlElementWrapper(name="build-types")
 	private List<DebRepositoryBuildTypeConfig> buildTypes = new CopyOnWriteArrayList<>();

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryStatistics.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/entity/DebRepositoryStatistics.java
@@ -25,5 +25,6 @@ public class DebRepositoryStatistics {
 	Integer totalPackageCount;
 	String repositoryUrl;
 	Integer totalFilterCount;
+	Boolean isRestricted;
 	
 }

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryConfigurationFactoryImpl.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryConfigurationFactoryImpl.java
@@ -43,6 +43,7 @@ public class DebRepositoryConfigurationFactoryImpl implements DebRepositoryConfi
 			}
 			newConfig.addBuildType(newBtConfig);
 		}
+		newConfig.setRestricted(sourceConfig.isRestricted());
 		newConfig.getArchitecturesRepresentedByAll().clear();
 		for (String arch : sourceConfig.getArchitecturesRepresentedByAll()) {
 			newConfig.getArchitecturesRepresentedByAll().add(new String(arch));

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryConfigurationManagerImpl.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryConfigurationManagerImpl.java
@@ -257,6 +257,15 @@ public abstract class DebRepositoryConfigurationManagerImpl implements DebReposi
 		return copiedConfigs;
 	}
 	
+	@Override
+	public boolean isRestrictedRepository(String repoName) throws NonExistantRepositoryException {
+		DebRepositoryConfiguration conf = getDebRepositoryConfigurationByName(repoName);
+		if (conf == null) {
+			throw new NonExistantRepositoryException();
+		}
+		return conf.isRestricted();
+	}
+	
 	private static class DebRepositoryConfigurationAlphabeticComparator implements Comparator<DebRepositoryConfiguration> {
 		@Override
 		public int compare(DebRepositoryConfiguration o1, DebRepositoryConfiguration o2) {

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryManager.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryManager.java
@@ -16,7 +16,6 @@
 package debrepo.teamcity.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -48,6 +47,7 @@ public interface DebRepositoryManager {
 	public boolean isExistingRepository(String repoName);
 	public boolean isExistingRepository(UUID uuid);
 	public void removeRepository(UUID uuid);
+	public boolean isRestrictedRepository(String repoName) throws NonExistantRepositoryException;
 	
 	void addBuildPackages(DebRepositoryConfiguration debRepositoryConfiguration, List<DebPackage> newPackages) throws NonExistantRepositoryException;
 	public void removeBuildPackages(DebPackageRemovalBean packageRemovalBean);
@@ -59,6 +59,7 @@ public interface DebRepositoryManager {
 		private Long buildId;
 		private List<DebPackage> packagesToKeep;
 	}
+
 
 
 }

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryManagerImpl.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/service/DebRepositoryManagerImpl.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -132,7 +131,7 @@ public class DebRepositoryManagerImpl extends  DebRepositoryConfigurationManager
 		for (DebRepositoryBuildTypeConfig btConfig : config.getBuildTypes()) {
 			filterCount = filterCount + btConfig.getDebFilters().size();
 		}
-		return new DebRepositoryStatistics(repositories.get(UUID.fromString(uuid)).size(), repoURL, filterCount);
+		return new DebRepositoryStatistics(repositories.get(UUID.fromString(uuid)).size(), repoURL, filterCount, config.isRestricted());
 	}
 	
 	@Override

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/util/StringUtils.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/util/StringUtils.java
@@ -30,8 +30,20 @@ public class StringUtils {
     	
     }
 
-	public static String getDebRepoUrl(String rootUrl, String repositoryName) {
-		return stripTrailingSlash(rootUrl) + DebDownloadController.DEBREPO_BASE_URL + "/" + repositoryName + "/";
+	public static String getDebRepoUrl(String rootUrl, String repositoryName, boolean isRestricted) {
+		if (isRestricted) {
+			return stripTrailingSlash(rootUrl) + DebDownloadController.DEBREPO_BASE_URL_FOR_REDIRECT_RESTRICTED + "/" + repositoryName + "/";
+		}
+		return stripTrailingSlash(rootUrl) + DebDownloadController.DEBREPO_BASE_URL_FOR_REDIRECT_UNRESTRICTED + "/" + repositoryName + "/";
 	}
-
+	
+	public static String getDebRepoUrlWithUserPassExample(String rootUrl, String repositoryName, boolean isRestricted) {
+		if (isRestricted) {
+			return getDebRepoUrl(rootUrl, repositoryName, isRestricted)
+					.replaceFirst("(^https?://)", "$1<em><strong>username:password</strong></em>@");
+		}
+		return getDebRepoUrl(rootUrl, repositoryName, isRestricted); 
+		
+	}
+	
 }

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebDownloadRestrictedAccessController.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebDownloadRestrictedAccessController.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ *
+ *  Copyright 2017 Net Wolf UK
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  
+ *  
+ *******************************************************************************/
+package debrepo.teamcity.web;
+
+import debrepo.teamcity.service.DebRepositoryConfigurationManager;
+import debrepo.teamcity.service.DebRepositoryManager;
+import debrepo.teamcity.service.NonExistantRepositoryException;
+import jetbrains.buildServer.controllers.AuthorizationInterceptor;
+import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.auth.AuthUtil;
+import jetbrains.buildServer.serverSide.auth.SecurityContext;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import jetbrains.buildServer.web.openapi.WebControllerManager;
+
+public class DebDownloadRestrictedAccessController extends DebDownloadController {
+
+//	public final String DEBREPO_URL_PART = "/debrepo-restricted";
+//	public final String DEBREPO_BASE_URL = "/app" + DEBREPO_URL_PART;
+//	private final String DEBREPO_BASE_URL_WITH_WILDCARD = DEBREPO_BASE_URL + "/**";
+	private final SecurityContext mySecurityContext;
+	private DebRepositoryConfigurationManager myDebRepositoryConfigManager;
+
+	public DebDownloadRestrictedAccessController(SBuildServer sBuildServer, WebControllerManager webControllerManager,
+			PluginDescriptor descriptor, AuthorizationInterceptor authorizationInterceptor,
+			DebRepositoryManager debRepositoryManager, DebRepositoryConfigurationManager debRepositoryConfigurationManager, 
+			SecurityContext securityContext) {
+		super(sBuildServer, webControllerManager, descriptor, authorizationInterceptor, debRepositoryManager);
+		mySecurityContext = securityContext;
+		myDebRepositoryConfigManager = debRepositoryConfigurationManager;
+	}
+	
+	@Override
+	protected void configureUrlAndAuthorisation(WebControllerManager webControllerManager, AuthorizationInterceptor authorizationInterceptor) {
+		webControllerManager.registerController(DEBREPO_BASE_URL_RESTRICTED_WITH_WILDCARD, this);
+	}
+
+	@Override
+	protected void checkRepoIsRestricted(String repoName) throws DebRepositoryAccessIsRestrictedException, DebRepositoryPermissionDeniedException, NonExistantRepositoryException {
+		if (myDebRepositoryManager.isRestrictedRepository(repoName)) {
+			String projectId = myDebRepositoryConfigManager.getDebRepositoryConfigurationByName(repoName).getProjectId();
+			if (! AuthUtil.hasReadAccessTo(mySecurityContext.getAuthorityHolder(), projectId)) {
+				throw new DebRepositoryPermissionDeniedException();
+			}
+		}
+	}
+	
+	@Override
+	protected String getDebRepoUrlPart() {
+		return DEBREPO_URL_PART_RESTRICTED;
+	}
+
+	@Override
+	protected String getDebRepoUrlPartWithContext() {
+		return DEBREPO_BASE_URL_RESTRICTED;
+	}
+
+}

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebDownloadUnRestrictedAccessController.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebDownloadUnRestrictedAccessController.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ *
+ *  Copyright 2017 Net Wolf UK
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  
+ *  
+ *******************************************************************************/
+package debrepo.teamcity.web;
+
+import debrepo.teamcity.service.DebRepositoryConfigurationManager;
+import debrepo.teamcity.service.DebRepositoryManager;
+import debrepo.teamcity.service.NonExistantRepositoryException;
+import jetbrains.buildServer.controllers.AuthorizationInterceptor;
+import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.auth.SecurityContext;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import jetbrains.buildServer.web.openapi.WebControllerManager;
+
+public class DebDownloadUnRestrictedAccessController extends DebDownloadController {
+
+	public DebDownloadUnRestrictedAccessController(SBuildServer sBuildServer, WebControllerManager webControllerManager,
+			PluginDescriptor descriptor, AuthorizationInterceptor authorizationInterceptor,
+			DebRepositoryManager debRepositoryManager, DebRepositoryConfigurationManager debRepositoryConfigurationManager, 
+			SecurityContext securityContext) {
+		super(sBuildServer, webControllerManager, descriptor, authorizationInterceptor, debRepositoryManager);
+	}
+	
+	@Override
+	protected void configureUrlAndAuthorisation(WebControllerManager webControllerManager, AuthorizationInterceptor authorizationInterceptor) {
+		webControllerManager.registerController(DEBREPO_BASE_URL_UNRESTRICTED_WITH_WILDCARD, this);
+		authorizationInterceptor.addPathNotRequiringAuth(DEBREPO_BASE_URL_UNRESTRICTED_WITH_WILDCARD);
+	}
+
+	@Override
+	protected void checkRepoIsRestricted(String repoName) throws DebRepositoryAccessIsRestrictedException, DebRepositoryPermissionDeniedException, NonExistantRepositoryException {
+		if (myDebRepositoryManager.isRestrictedRepository(repoName)) {
+			throw new DebRepositoryAccessIsRestrictedException();
+		}
+	}
+	
+	@Override
+	protected String getDebRepoUrlPart() {
+		return DEBREPO_URL_PART_UNRESTRICTED;
+	}
+
+	@Override
+	protected String getDebRepoUrlPartWithContext() {
+
+		return DEBREPO_URL_PART_UNRESTRICTED;
+	}
+
+}

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoConfigurationEditPageActionController.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoConfigurationEditPageActionController.java
@@ -33,6 +33,7 @@ public class DebRepoConfigurationEditPageActionController extends BaseAjaxAction
 	public static final String ACTION_TYPE = "action";
     public static final String DEBREPO_UUID = "debrepo.uuid";
     public static final String DEBREPO_NAME = "debrepo.name";
+    public static final String DEBREPO_RESTRICTED = "debrepo.restricted";
     public static final String DEBREPO_PROJECT_ID = "debrepo.project.id";
     public static final String DEBREPO_FILTER_ID = "debrepo.filter.id";
     public static final String DEBREPO_FILTER_REGEX = "debrepo.filter.regex";

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoConfigurationEditPageController.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoConfigurationEditPageController.java
@@ -85,7 +85,8 @@ public class DebRepoConfigurationEditPageController extends BaseController {
 											repoConfig, 
         									StringUtils.getDebRepoUrl(
         											myServer.getRootUrl(), 
-        											repoConfig.getRepoName()
+        											repoConfig.getRepoName(),
+        											repoConfig.isRestricted()
         											)
         									)
         							);

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoListingPageController.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoListingPageController.java
@@ -85,7 +85,8 @@ public class DebRepoListingPageController extends BaseController {
 						   						config, 
 						   						StringUtils.getDebRepoUrl(
 						   										myServer.getRootUrl(), 
-						   										config.getRepoName())
+						   										config.getRepoName(),
+						   										config.isRestricted())
 						   						), 
 							permissioned)
 					);

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoProjectSettingsTab.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepoProjectSettingsTab.java
@@ -102,7 +102,8 @@ public class DebRepoProjectSettingsTab extends EditProjectTab {
         									config, 
         									StringUtils.getDebRepoUrl(
         											myServer.getRootUrl(), 
-        											config.getRepoName()
+        											config.getRepoName(),
+        											config.isRestricted()
         											)
         									)
         							)

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepositoryAccessIsRestrictedException.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepositoryAccessIsRestrictedException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ *
+ *  Copyright 2017 Net Wolf UK
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  
+ *  
+ *******************************************************************************/
+package debrepo.teamcity.web;
+
+public class DebRepositoryAccessIsRestrictedException extends Exception {
+
+	private static final long serialVersionUID = -1448887202484970704L;
+
+}

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepositoryPermissionDeniedException.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/DebRepositoryPermissionDeniedException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ *
+ *  Copyright 2017 Net Wolf UK
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  
+ *  
+ *******************************************************************************/
+package debrepo.teamcity.web;
+
+public class DebRepositoryPermissionDeniedException extends Exception {
+
+	private static final long serialVersionUID = -5234855075557228275L;
+
+}

--- a/tcdebrepo-server/src/main/java/debrepo/teamcity/web/action/EditRepositoryAction.java
+++ b/tcdebrepo-server/src/main/java/debrepo/teamcity/web/action/EditRepositoryAction.java
@@ -18,7 +18,9 @@
  *******************************************************************************/
 package debrepo.teamcity.web.action;
 
-import static debrepo.teamcity.web.DebRepoConfigurationEditPageActionController.*;
+import static debrepo.teamcity.web.DebRepoConfigurationEditPageActionController.DEBREPO_NAME;
+import static debrepo.teamcity.web.DebRepoConfigurationEditPageActionController.DEBREPO_PROJECT_ID;
+import static debrepo.teamcity.web.DebRepoConfigurationEditPageActionController.DEBREPO_RESTRICTED;
 import static debrepo.teamcity.web.DebRepoConfigurationEditPageActionController.DEBREPO_UUID;
 
 import java.util.Enumeration;
@@ -37,7 +39,6 @@ import debrepo.teamcity.service.DebRepositoryConfigurationManager;
 import debrepo.teamcity.util.RepositoryNameValidator;
 import debrepo.teamcity.util.RepositoryNameValidator.RepositoryNameValidationResult;
 import debrepo.teamcity.web.DebRepoConfigurationEditPageActionController;
-import debrepo.teamcity.web.action.ArtifactFilterAction.IncompleteFilterException;
 import jetbrains.buildServer.controllers.ActionMessages;
 import jetbrains.buildServer.web.openapi.ControllerAction;
 
@@ -64,11 +65,13 @@ public class EditRepositoryAction extends ArtifactFilterAction implements Contro
 		String repoUuid;
 		String repoName;
 		String projectId;
+		boolean restricted = false;
 		Set<String> archs = new TreeSet<>();
 		try {
 			repoUuid = getParameterAsStringOrNull(request, DEBREPO_UUID, "request is missing repo uuid");
 			repoName = getParameterAsStringOrNull(request, DEBREPO_NAME, "Please enter a Repository Name");
 			projectId = getParameterAsStringOrNull(request, DEBREPO_PROJECT_ID, "Please choose a project");
+			restricted = Boolean.valueOf(getParameterAsStringOrNull(request, DEBREPO_RESTRICTED, "Request is missing restricted setting"));
 		} catch (IncompleteFilterException e) {
 			ajaxResponse.setAttribute("error", e.getMessage());
 			return;
@@ -101,6 +104,11 @@ public class EditRepositoryAction extends ArtifactFilterAction implements Contro
 			}
 			if (!debConfig.getProjectId().equals(projectId)) {
 				debConfig.setProjectId(projectId);
+				change = true;
+			}
+			
+			if (debConfig.isRestricted() != restricted) {
+				debConfig.setRestricted(restricted);
 				change = true;
 			}
 			

--- a/tcdebrepo-server/src/main/resources/META-INF/build-server-plugin-tcdebrepo.xml
+++ b/tcdebrepo-server/src/main/resources/META-INF/build-server-plugin-tcdebrepo.xml
@@ -4,8 +4,12 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
        default-autowire="constructor">
 
-       <bean id="debDownloadController"
-     	class="debrepo.teamcity.web.DebDownloadController" 
+       <bean id="debDownloadUnRestrictedAccessController"
+     	class="debrepo.teamcity.web.DebDownloadUnRestrictedAccessController" 
+     	/>
+
+       <bean id="debDownloadRestrictedAccessController"
+     	class="debrepo.teamcity.web.DebDownloadRestrictedAccessController" 
      	/>
 
        <bean id="debRepoBuildTypeTab"

--- a/tcdebrepo-server/src/main/resources/buildServerResources/debRepository/editDebianRepository.js
+++ b/tcdebrepo-server/src/main/resources/buildServerResources/debRepository/editDebianRepository.js
@@ -162,6 +162,7 @@ DebRepoPlugin = {
     				action: $j("#editRepoForm #DebRepoaction").val(),
     				"debrepo.uuid": $j("#editRepoForm input[id='debrepo.uuid']").val(),
     				"debrepo.name": $j("#editRepoForm input[id='debrepo.name']").val(),
+    				"debrepo.restricted": $j("#editRepoForm input[id='debrepo.restricted']").prop("checked"),
     				"debrepo.project.id": $j("#editRepoForm select[id='debrepo.project.id']").val()
     		};
     		

--- a/tcdebrepo-server/src/main/resources/buildServerResources/debRepository/editDebianRepository.jsp
+++ b/tcdebrepo-server/src/main/resources/buildServerResources/debRepository/editDebianRepository.jsp
@@ -95,6 +95,10 @@
           <th style="width:15%;">&quot;All&quot; Architectures:</th>
           <td style="width:85%;" colspan="3">${debRepoBean.allArchsAsCSL}</td>
         </tr>
+        <tr>
+          <th style="width:15%;">Restricted Access:</th>
+          <td style="width:85%;" colspan="3">${repoStats.isRestricted ? 'Authentication required' : 'No authentication required' }</td>
+        </tr>
       </table>
       
           <bs:dialog dialogId="editRepoDialog"
@@ -135,6 +139,16 @@
                         </div>
                         The project this repository belongs to. Users with the Project Administrator Role for this project can edit this repository configuration. 
                         When adding/editing Artifact Filters, only builds from this project or sub-projects are available to choose from.</p>
+                    </td>
+                </tr>
+                 <tr>    
+                 	<th>Restricted Access</th>                
+                    <td>
+                        <div>
+  							<label><input type="checkbox" id="debrepo.restricted" name="debrepo.restricted" ${repoStats.isRestricted ? 'checked' : '' }> Authentication Required</label>
+                        </div>
+                        Whether the repository requires a username and password for access. If a repository is restricted, the APT client must present valid TeamCity credentials
+                        and the account must have read permission on the project specified above (or a subproject).   
                     </td>
                 </tr>
                  <tr>    

--- a/tcdebrepo-server/src/test/java/debrepo/teamcity/util/StringUtilsTest.java
+++ b/tcdebrepo-server/src/test/java/debrepo/teamcity/util/StringUtilsTest.java
@@ -1,0 +1,34 @@
+package debrepo.teamcity.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+	@Test
+	public void testStripTrailingSlash() {
+		assertEquals("https://some.thing/with/a/slash/on/the/end", StringUtils.stripTrailingSlash("https://some.thing/with/a/slash/on/the/end/"));
+	}
+
+	@Test
+	public void testGetDebRepoUrl() {
+		assertEquals("https://some.thing/httpAuth/app/debrepo-restricted/Test01/", 
+				StringUtils.getDebRepoUrl("https://some.thing/", 
+											"Test01", true));
+		assertEquals("https://some.thing/app/debrepo/Test01/", 
+				StringUtils.getDebRepoUrl("https://some.thing/", 
+						"Test01", false));
+	}
+
+	@Test
+	public void testGetDebRepoUrlWithUserPassExample() {
+		assertEquals("https://<em><strong>username:password</strong></em>@some.thing/httpAuth/app/debrepo-restricted/Test01/", 
+					StringUtils.getDebRepoUrlWithUserPassExample("https://some.thing/", 
+												"Test01", true));	
+		assertEquals("https://some.thing/app/debrepo/Test01/", 
+				StringUtils.getDebRepoUrlWithUserPassExample("https://some.thing/", 
+						"Test01", false));	
+	}
+
+}


### PR DESCRIPTION
As per issue #11

- Added a new controller registered at the alternative URL
/app/debrepo-restricted/*

- The new controller requires authentication (using TeamCity Auth and
permissions) and checks that the user has read permission on the project
that the repo is associated to.

- Added a setting on a repository that indicates if authentication is
required

- Added a redirect so that http requests to the unrestricted repository
address send the browser to the restricted address.

- Added UI to set the restricted setting.

- Updated the various links to the repositories to point to the relevant
location.